### PR TITLE
fix(nvim): broken syntax highlighting problem cause by LSP

### DIFF
--- a/.config/nvim/plugin/lspconfig.lua
+++ b/.config/nvim/plugin/lspconfig.lua
@@ -21,6 +21,10 @@ end
 -- after the language server attaches to the current buffer
 local on_attach = function(client, bufnr)
   local function buf_set_keymap(...) vim.api.nvim_buf_set_keymap(bufnr, ...) end
+  -- fix broken syntax highlighting problem
+  client.server_capabilities.semanticTokensProvider = nil
+
+  
 
   --Enable completion triggered by <c-x><c-o>
   --local function buf_set_option(...) vim.api.nvim_buf_set_option(bufnr, ...) end


### PR DESCRIPTION
Fixing syntax highlighting problem cause by lsp.
Via `:Telescope current_buffer_fuzzy_finder`, syntax highlighting on the preview appears to be fine, additionally with `:LspRestart`, it works for a few seconds then revert back to broken state. 
Was able to fix it with [lsp_semantics](https://github.com/neovim/neovim/commit/9b14ad5fd9e15718aa938f7a426dddcc2edab4e3#diff-6b5f3071d65558aab177912061ac6a2f5312660655a449276c83697686f28e72)